### PR TITLE
feat: add tupple arguments support

### DIFF
--- a/odps/tests/test_utils.py
+++ b/odps/tests/test_utils.py
@@ -53,13 +53,33 @@ def bothPyAndC(func):
 
 class Test(TestBase):
     def testReplaceSqlParameters(self):
-        ns = {'test1': 'new_test1', 'test3': 'new_\'test3\''}
-
-        sql = 'select :test1 from dual where :test2 > 0 and f=:test3.abc'
-        replaced_sql = utils.replace_sql_parameters(sql, ns)
-
-        expected = 'select \'new_test1\' from dual where :test2 > 0 and f=\'new_\\\'test3\\\'\'.abc'
-        self.assertEqual(expected, replaced_sql)
+        cases = [
+        {
+            'ns': {'test1': 'new_test1', 'test3': 'new_\'test3\''},
+            'sql': 'select :test1 from dual where :test2 > 0 and f=:test3.abc',
+            'expected': "select 'new_test1' from dual where :test2 > 0 and f='new_\\'test3\\''.abc"
+        },
+        {
+            'ns': {
+                'dss': ('20180101', '20180102', 20180101),
+            },
+            'sql': 'select * from dual where id in :dss',
+            'expected': "select * from dual where id in ('20180101', '20180102', 20180101)"
+        },
+          {
+            'ns': {
+                'ds': '20180101',
+                'dss': ('20180101', 20180101),
+                'id': 21312,
+                'price': 6.4,
+                'prices': (123, '123', 6.4)
+            },
+            'sql': 'select * from dual where ds = :ds or ds in :dss and id = :id and price > :price or price in :prices',
+            'expected': "select * from dual where ds = '20180101' or ds in ('20180101', 20180101) and id = 21312 and price > 6.4 or price in (123, '123', 6.4)"
+        }
+        ]
+        for case in cases:
+            self.assertEqual(case['expected'], utils.replace_sql_parameters(case['sql'], case['ns']))
 
     def testExperimental(self):
         @utils.experimental('Experimental method')


### PR DESCRIPTION
This pull requests add's tuple arguments parameters to sql magic.

```
dss = ('20180101', '20180102', 20180101)

%sql
select * from dual where ds in :dss
```

-> executes sql 
`select * from dual where ds in ('20180101', '20180102', 20180101)`