### PR TITLE
feat: add tuple arguments support

### DIFF
--- a/odps/tests/test_utils.py
+++ b/odps/tests/test_utils.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2017 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,18 +55,35 @@ class Test(TestBase):
     def testReplaceSqlParameters(self):
         cases = [
         {
+            'ns': {
+                'dss': ['20180101', '20180102', '20180101'],
+            },
+            'sql': 'select * from dual where id in :dss',
+            'expected': ["select * from dual where id in ('20180101', '20180102', '20180101')"]
+        },
+        {
+            'ns': {
+                'dss': set(['20180101', '20180102', '20180101']),
+            },
+            'sql': 'select * from dual where id in :dss',
+            'expected': [
+                "select * from dual where id in ('20180101', '20180102')",
+                "select * from dual where id in ('20180102', '20180101')"
+            ]
+        },
+        {
             'ns': {'test1': 'new_test1', 'test3': 'new_\'test3\''},
             'sql': 'select :test1 from dual where :test2 > 0 and f=:test3.abc',
-            'expected': "select 'new_test1' from dual where :test2 > 0 and f='new_\\'test3\\''.abc"
+            'expected': ["select 'new_test1' from dual where :test2 > 0 and f='new_\\'test3\\''.abc"]
         },
         {
             'ns': {
                 'dss': ('20180101', '20180102', 20180101),
             },
             'sql': 'select * from dual where id in :dss',
-            'expected': "select * from dual where id in ('20180101', '20180102', 20180101)"
+            'expected': ["select * from dual where id in ('20180101', '20180102', 20180101)"]
         },
-          {
+        {
             'ns': {
                 'ds': '20180101',
                 'dss': ('20180101', 20180101),
@@ -75,11 +92,11 @@ class Test(TestBase):
                 'prices': (123, '123', 6.4)
             },
             'sql': 'select * from dual where ds = :ds or ds in :dss and id = :id and price > :price or price in :prices',
-            'expected': "select * from dual where ds = '20180101' or ds in ('20180101', 20180101) and id = 21312 and price > 6.4 or price in (123, '123', 6.4)"
+            'expected': ["select * from dual where ds = '20180101' or ds in ('20180101', 20180101) and id = 21312 and price > 6.4 or price in (123, '123', 6.4)"]
         }
         ]
         for case in cases:
-            self.assertEqual(case['expected'], utils.replace_sql_parameters(case['sql'], case['ns']))
+            self.assertIn(utils.replace_sql_parameters(case['sql'], case['ns']), case['expected'])
 
     def testExperimental(self):
         @utils.experimental('Experimental method')

--- a/odps/tests/test_utils.py
+++ b/odps/tests/test_utils.py
@@ -53,13 +53,33 @@ def bothPyAndC(func):
 
 class Test(TestBase):
     def testReplaceSqlParameters(self):
-        ns = {'test1': 'new_test1', 'test3': 'new_\'test3\''}
-
-        sql = 'select :test1 from dual where :test2 > 0 and f=:test3.abc'
-        replaced_sql = utils.replace_sql_parameters(sql, ns)
-
-        expected = 'select \'new_test1\' from dual where :test2 > 0 and f=\'new_\\\'test3\\\'\'.abc'
-        self.assertEqual(expected, replaced_sql)
+        cases = [
+        {
+            'ns': {'test1': 'new_test1', 'test3': 'new_\'test3\''},
+            'sql': 'select :test1 from dual where :test2 > 0 and f=:test3.abc',
+            'expected': "select 'new_test1' from dual where :test2 > 0 and f='new_\\'test3\\''.abc"
+        },
+        {
+            'ns': {
+                'dss': ('20180101', '20180102', 20180101),
+            },
+            'sql': 'select * from dual where id in :dss',
+            'expected': "select * from dual where id in ('20180101', '20180102', 20180101)"
+        },
+          {
+            'ns': {
+                'ds': '20180101',
+                'dss': ('20180101', 20180101),
+                'id': 21312,
+                'price': 6.4,
+                'prices': (123, '123', 6.4)
+            },
+            'sql': 'select * from dual where ds = :ds or ds in :dss and id = :id and price > :price or price in :prices',
+            'expected': "select * from dual where ds = '20180101' or ds in ('20180101', 20180101) and id = 21312 and price > 6.4 or price in (123, '123', 6.4)"
+        }
+        ]
+        for case in cases:
+            self.assertEqual(case['expected'], utils.replace_sql_parameters(case['sql'], case['ns']))
 
     def testExperimental(self):
         @utils.experimental('Experimental method')

--- a/odps/utils.py
+++ b/odps/utils.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 1999-2017 Alibaba Group Holding Ltd.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -628,10 +628,18 @@ def replace_sql_parameters(sql, ns):
     def is_numeric(val):
         return isinstance(val, (six.integer_types, float))
 
+    def is_sequence(val):
+        return isinstance(val, (tuple, set, list))
+
     def format_string(val):
         return "'{0}'".format(escape_odps_string(str(val)))
+
     def format_numeric(val):
         return repr(val)
+
+    def format_sequence(val):
+        escaped = [format_numeric(v) if is_numeric(v) else format_string(v) for v in val]
+        return '({0})'.format(', '.join(escaped))
 
     def replace(matched):
         name = matched.group(1)
@@ -640,8 +648,8 @@ def replace_sql_parameters(sql, ns):
             return matched.group(0)
         elif is_numeric(val):
             return format_numeric(val)
-        elif isinstance(val, tuple):
-            return '({0})'.format(', '.join(map(lambda v: format_numeric(v) if is_numeric(v) else format_string(v), val)))
+        elif is_sequence(val):
+            return format_sequence(val)
         else:
             return format_string(val)
 


### PR DESCRIPTION
This pull requests add's tuple arguments parameters to sql magic.

```
dss = ('20180101', '20180102', 20180101)

%sql
select * from dual where ds in :dss
```

-> executes sql 
`select * from dual where ds in ('20180101', '20180102', 20180101)`