### PR TITLE
Set a default parameter for table.head()

### DIFF
--- a/odps/models/table.py
+++ b/odps/models/table.py
@@ -366,7 +366,7 @@ class Table(LazyLoad):
             location=self.location, resources=self.resources,
         )
 
-    def head(self, limit, partition=None, columns=None):
+    def head(self, limit=20, partition=None, columns=None):
         """
         Get the head records of a table or its partition.
 


### PR DESCRIPTION
Most user prefer to use `table.head()` rather then `table.head(20)`. This is because you can use `df.head()` in *pandas* or *pyspark*. Set a default parameter for `table.head()` is a wise choice.