### PR TITLE
Update readers.py in cases where the next record contains Empty list instead of None

### DIFF
--- a/odps/readers.py
+++ b/odps/readers.py
@@ -360,6 +360,8 @@ class CsvRecordReader(AbstractRecordReader):
         values = self._readline()
         if values is None:
             raise StopIteration
+        if len(values) == 0:
+            raise StopIteration
 
         if self._filtered_col_idxes:
             values = [values[idx] for idx in self._filtered_col_idxes]

--- a/odps/readers.py
+++ b/odps/readers.py
@@ -358,9 +358,7 @@ class CsvRecordReader(AbstractRecordReader):
         self._load_columns()
 
         values = self._readline()
-        if values is None:
-            raise StopIteration
-        if len(values) == 0:
+        if values is None or len(values)==0:
             raise StopIteration
 
         if self._filtered_col_idxes:

--- a/odps/readers.py
+++ b/odps/readers.py
@@ -358,7 +358,7 @@ class CsvRecordReader(AbstractRecordReader):
         self._load_columns()
 
         values = self._readline()
-        if values is None or len(values)==0:
+        if values is None or len(values) == 0:
             raise StopIteration
 
         if self._filtered_col_idxes:


### PR DESCRIPTION
Handle cases in `readers.py` where the next record is an empty list instead of `None`

Otherwise, it will throw a ValueError of

`ValueError: The values set to records are against the schema, expect len 1, got len 0`
