### PR TITLE
Map pyarrow large_string to ODPS string type

### DIFF
--- a/odps/tunnel/io/types.py
+++ b/odps/tunnel/io/types.py
@@ -25,6 +25,7 @@ except (AttributeError, ImportError):
 if pa is not None:
     _ARROW_TO_ODPS_TYPE = {
         pa.string(): odps_types.string,
+        pa.large_string(): odps_types.string,
         pa.binary(): odps_types.binary,
         pa.int8(): odps_types.tinyint,
         pa.int16(): odps_types.smallint,


### PR DESCRIPTION
# Summary
Adds support for PyArrow's large_string type in the Arrow-to-ODPS type mapping used by tunnel I/O. Without this mapping, columns produced as pa.large_string() (e.g., from pyarrow.compute operations, concat_tables on large data, or upstream libraries that emit large string arrays) fail to resolve to an ODPS type, causing tunnel uploads/conversions to break.

This change maps pa.large_string() to odps_types.string, matching the existing handling for pa.string().

# Changes
- odps/tunnel/io/types.py: add pa.large_string(): odps_types.string entry to _ARROW_TO_ODPS_TYPE.

# Why large_string → string
ODPS only has a single variable-length string type (STRING), so both pa.string() (32-bit offsets) and pa.large_string() (64-bit offsets) should serialize to the same ODPS type. The reverse mapping (_ODPS_TO_ARROW_TYPE) intentionally keeps odps_types.string → pa.string() as the canonical Arrow representation.

# Risks
- Low. Single-line addition to a lookup dict; no behavior change for existing types. The reverse mapping is unchanged, so writes from ODPS to Arrow remain
identical.